### PR TITLE
fix bug on query timeout result

### DIFF
--- a/src/p1_mysql_conn.erl
+++ b/src/p1_mysql_conn.erl
@@ -224,7 +224,7 @@ wait_fetch_result(TRef, Pid) ->
 	    wait_fetch_result(TRef, Pid);
 	{timeout, TRef, _Info} ->
 	    stop(Pid),
-	    {error, "query timed out"}
+	    {error, #p1_mysql_result{error="query timed out"}}
     end.
 
 stop(Pid) ->


### PR DESCRIPTION
will lead to an ejabberd_odbc function_clause which assume result is a p1_mysql_result
