### PR TITLE
enable tcp keepalive to capture zombie connections

### DIFF
--- a/src/p1_mysql_recv.erl
+++ b/src/p1_mysql_recv.erl
@@ -95,7 +95,7 @@ start_link(Host, Port, LogFun, Parent) when is_list(Host), is_integer(Port) ->
 %% Returns : error | never returns
 %%--------------------------------------------------------------------
 init(Host, Port, LogFun, Parent) ->
-    case gen_tcp:connect(Host, Port, [binary, {packet, 0}]) of
+    case gen_tcp:connect(Host, Port, [binary, {packet, 0}, {keepalive, true}]) of
 	{ok, Sock} ->
 	    Parent ! {p1_mysql_recv, self(), init, {ok, Sock}},
 	    State = #state{socket  = Sock,


### PR DESCRIPTION
The load balancer service of our cloud service provider has a bug on connection maintenance, which will not send connection reset signal to client when the connection between LB and backend server was corrupted. Client not aware of this situation will keep sending the requests to LB but only found that the data was cached in tcp send queue. 

This parameter might be not necessary for other reliable services, it has no side effect IMO and still be a considerable defensive action.
